### PR TITLE
Reset PullRequestCount

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,6 +58,8 @@ func main() {
 }
 
 func snapshot() error {
+	PullRequestCount.Reset()
+
 	githubToken, err := readGithubConfig()
 	if err != nil {
 		return fmt.Errorf("failed to read Datadog Config: %w", err)


### PR DESCRIPTION
## Problem
A count doesn't change if I close a pull-request.
<img width="682" alt="Screen Shot 2021-01-26 at 13 39 14" src="https://user-images.githubusercontent.com/10370988/105801189-f5b9c080-5fdb-11eb-8dbb-a1ee95069343.png">

## Cause
PullRequestCount exists for each pull request.
It remains if it is reset.

## How to solve
It should be reset when it collects metrics.