### PR TITLE
add lifetime_days label to prometheus metrics

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,2 +1,4 @@
 export GITHUB_TOKEN="secret"
 export GITHUB_REPOSITORIES="chaspy/github-pr-prometheus-exporter,chaspy/favsearch"
+# LIFETIME_STALE_DAYS is optional, default is 14 days
+# export LIFETIME_STALE_DAYS=14

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func getLifetimeStaleDays() (int, error) {
 
 	integerLifetimeStaleDays, err := strconv.Atoi(lifetimeStaleDays)
 	if err != nil {
-		return 0, fmt.Errorf("failed to read Datadog Config: %w", err)
+		return 0, fmt.Errorf("failed to convert lifetimeStaleDays: %w", err)
 	}
 
 	return integerLifetimeStaleDays, nil


### PR DESCRIPTION
Hi @chaspy, Thanks for the wonderful OSS!
There was a feature that I would like to see added, so I made it a PR. Could you review the content when you have time?

### Problem

We would like to measure an indicator about the lifetime of PR.

In particular, we would like to measure not only how many PRs are accumulated, but also the average lifetime, or the number of PRs that remain alive for more than a month, for example, to provide a deeper insight than simply how many PRs are accumulated.

### How to solve

The indicator is added to the label by subtracting the date the PR was created from the current time and converting it to a number of days.

I think it is good enough to round the lifetime to the number of days, but if there are any suggestions, I would like to follow them.